### PR TITLE
Fix for empty report stream

### DIFF
--- a/repository/SMark/ReBenchHarness.class.st
+++ b/repository/SMark/ReBenchHarness.class.st
@@ -5,27 +5,28 @@ It is especially meant to be used together with ReBench, a tool to execute and d
 See: https://github.com/smarr/ReBench#readme
 "
 Class {
-	#name : #ReBenchHarness,
-	#superclass : #SMarkHarness,
-	#category : 'SMark'
+	#name : 'ReBenchHarness',
+	#superclass : 'SMarkHarness',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #helper }
+{ #category : 'helper' }
 ReBenchHarness class >> defaultArgumentParser [
 	^ ReBenchHarnessArgumentParser
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ReBenchHarness class >> defaultReporter [
 	^ ReBenchReporter
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ReBenchHarness class >> defaultRunner [
 	^ SMarkWeakScalingRunner
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 ReBenchHarness class >> usageBenchmarkParameters: usage [
 	^ usage,		' processes          optional, number of processes/threads used by the benchmarks', String crlf,
 				' inner-iterations   optional, number of iterations done by a single process', String crlf,
@@ -33,7 +34,7 @@ ReBenchHarness class >> usageBenchmarkParameters: usage [
 				
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 ReBenchHarness class >> usageHeader [
 	| usage |
 	usage := 'SMark Benchmark Framework, version: ', self version, String crlf.
@@ -49,13 +50,13 @@ ReBenchHarness class >> usageHeader [
 	^ usage
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 ReBenchHarness class >> usageReporter: usage [
 	"Will rely on default, which is good for ReBench, so do not advertise option."
 	^ usage
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 ReBenchHarness class >> usageRunner: usage [
 	"Will rely on default, which is good for ReBench, so do not advertise option."
 	^ usage

--- a/repository/SMark/ReBenchHarnessArgumentParser.class.st
+++ b/repository/SMark/ReBenchHarnessArgumentParser.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #ReBenchHarnessArgumentParser,
-	#superclass : #SMarkHarnessArgumentParser,
-	#category : 'SMark'
+	#name : 'ReBenchHarnessArgumentParser',
+	#superclass : 'SMarkHarnessArgumentParser',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 ReBenchHarnessArgumentParser >> determineBenchmarkParametersFromArguments [
 	i := i + 1.
 	i <= numParams ifTrue: [
@@ -20,17 +21,17 @@ ReBenchHarnessArgumentParser >> determineBenchmarkParametersFromArguments [
 	].
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 ReBenchHarnessArgumentParser >> determineReporter [
 	reporter := harness defaultReporter new.
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 ReBenchHarnessArgumentParser >> determineRunner [
 	runner := harness defaultRunner new.
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 ReBenchHarnessArgumentParser >> instructRunner [
 	super instructRunner.
 	

--- a/repository/SMark/ReBenchReporter.class.st
+++ b/repository/SMark/ReBenchReporter.class.st
@@ -3,12 +3,13 @@ A ReBenchReporter is reporter for the ReBench framework (cf. https://github.com/
 It is used be the ReBenchHarness, which is the main class of interest for users that just want to execute benchmarks.
 "
 Class {
-	#name : #ReBenchReporter,
-	#superclass : #SMarkSimpleStatisticsReporter,
-	#category : 'SMark'
+	#name : 'ReBenchReporter',
+	#superclass : 'SMarkSimpleStatisticsReporter',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 ReBenchReporter >> benchmarkHeader: aName [
 	^ self
 ]

--- a/repository/SMark/SMarkAutosizeRunner.class.st
+++ b/repository/SMark/SMarkAutosizeRunner.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #SMarkAutosizeRunner,
-	#superclass : #SMarkRunner,
+	#name : 'SMarkAutosizeRunner',
+	#superclass : 'SMarkRunner',
 	#instVars : [
 		'targetTime',
 		'innerLoopIterations'
 	],
-	#category : #SMark
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkAutosizeRunner class >> defaultTargetTime [
 	"300 milliseconds seems to be a reasonable target time for most problems.
 	 It is a compromise between the general measurment noise as well as timer accuracy
@@ -16,19 +17,19 @@ SMarkAutosizeRunner class >> defaultTargetTime [
 	^ 300
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkAutosizeRunner >> initialize [
 	super initialize.
 	targetTime := self class defaultTargetTime.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkAutosizeRunner >> innerLoopIterations [
 
 	^ innerLoopIterations
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkAutosizeRunner >> performBenchmark: aSelector [
 	"First determine a useful number of inner loop iterations until the targetTime is reached."
 	| execTime i |
@@ -49,7 +50,7 @@ SMarkAutosizeRunner >> performBenchmark: aSelector [
 	^ super performBenchmark: aSelector.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkAutosizeRunner >> runBaseBenchmark [
 	"baseBenchmark is not supported with autosizing. I do not see how that can be made possible since all different benchmarks will have different number of iterations, and the only way how a consistent baseline could be found would be to normalize the results, but well, incorporating the baseline measurement with the statistical evaluation is harder than just substracting a one time value..., I am not going to do that here for the moment. Stefan 2011-03-20"
 	
@@ -60,19 +61,19 @@ SMarkAutosizeRunner >> runBaseBenchmark [
 	self recordResults: (self class defaultTimer new: 'total') for: #baseBenchmark  
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkAutosizeRunner >> targetTime [
 	"Target time in milliseconds"
 	^ targetTime
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkAutosizeRunner >> targetTime: anIntInMilliseconds [
 	"Target time in milliseconds"
 	targetTime := anIntInMilliseconds
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkAutosizeRunner >> timedBenchmarkExecution: aSelector [
 	"Will do a timed execution of the benchmark and return the result timer"
 	| timer |

--- a/repository/SMark/SMarkAutosizeRunnerTest.class.st
+++ b/repository/SMark/SMarkAutosizeRunnerTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #SMarkAutosizeRunnerTest,
-	#superclass : #SMarkRunnerTest,
-	#category : 'SMark-Tests'
+	#name : 'SMarkAutosizeRunnerTest',
+	#superclass : 'SMarkRunnerTest',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkAutosizeRunnerTest class >> shouldInheritSelectors [
 	^ true
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkAutosizeRunnerTest >> runnerClass [
 	^ SMarkTestAutosizeRunner
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkAutosizeRunnerTest >> testAutosizing [
 	"Ensure that the runtime is automatically sized up to a predefined value"
 	| runner results big small runTime benchmarkSum |
@@ -57,7 +59,7 @@ SMarkAutosizeRunnerTest >> testAutosizing [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkAutosizeRunnerTest >> testAutosizingBaseBenchmark [
 	"Ensure that baseBenchmarks are not delivering any data since I do not see how that could be done nicely"
 	| runner results |
@@ -75,7 +77,7 @@ SMarkAutosizeRunnerTest >> testAutosizingBaseBenchmark [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkAutosizeRunnerTest >> testBaseBenchmark [
 	"Different from base test: Ensure the base benchmark is NOT executed when available"
 	
@@ -85,7 +87,7 @@ SMarkAutosizeRunnerTest >> testBaseBenchmark [
 	self deny: runner baseBenchmarkExecuted  
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkAutosizeRunnerTest >> testExecute [
 	"This test is slightly different from the one in the base class"
 	| runner results performedBenchmarks |
@@ -104,7 +106,7 @@ SMarkAutosizeRunnerTest >> testExecute [
 	self assert: (((results at: #baseBenchmark) at: 1) isKindOf: SMarkResult).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkAutosizeRunnerTest >> testIterations [
 	| runner |
 	"This test is different then the one in the base class, it is not direct, but just looks at the results"

--- a/repository/SMark/SMarkBenchmark.class.st
+++ b/repository/SMark/SMarkBenchmark.class.st
@@ -1,75 +1,76 @@
 Class {
-	#name : #SMarkBenchmark,
-	#superclass : #Object,
+	#name : 'SMarkBenchmark',
+	#superclass : 'Object',
 	#instVars : [
 		'suite',
 		'selector'
 	],
-	#category : #SMark
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkBenchmark >> benchmarkName [
 	
 	^ suite benchmarkNameForSelector: selector 
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkBenchmark >> benchmarkNameForSelector: aSelector [
 
 	^ suite benchmarkNameForSelector: aSelector
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkBenchmark >> performBenchmarkSelector: aSelector [
 
 	^ suite performBenchmarkSelector: aSelector
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkBenchmark >> processResult: aBoolean withTimer: aSMarkTimer [ 
 
 	^ suite processResult: aBoolean withTimer: aSMarkTimer
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkBenchmark >> runBenchmark: aString [ 
 
 	^ suite runBenchmark: aString
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkBenchmark >> runOn: aRunner [
 
 	aRunner performBenchmark: selector.
 	^ aRunner results at: self benchmarkName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkBenchmark >> runner: aRunner [
 
 	^ suite runner: aRunner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkBenchmark >> selector [
 
 	^ selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkBenchmark >> selector: anObject [
 
 	selector := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkBenchmark >> suite [
 
 	^ suite
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkBenchmark >> suite: anObject [
 
 	suite := anObject

--- a/repository/SMark/SMarkCogRunner.class.st
+++ b/repository/SMark/SMarkCogRunner.class.st
@@ -3,21 +3,22 @@ This runner is doing warmup on for Cog VMs with just-in-time compilation.
 The goal is to bring the JIT compiler into a steady state where no jitting is performed anymore during benchmarking.
 "
 Class {
-	#name : #SMarkCogRunner,
-	#superclass : #SMarkRunner,
+	#name : 'SMarkCogRunner',
+	#superclass : 'SMarkRunner',
 	#instVars : [
 		'warmingUp'
 	],
-	#category : 'SMark'
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkCogRunner >> initialize [
 	super initialize.
 	warmingUp := false.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkCogRunner >> performBenchmark: aSelector [
 	"Based on an email by Eliot from May 16th, 2011.
 	 The first time a method is executed it will get into the inline cache.
@@ -33,7 +34,7 @@ SMarkCogRunner >> performBenchmark: aSelector [
 	^ super performBenchmark: aSelector.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkCogRunner >> recordResults: timer for: aSelector [
 	"Only record the results when we are not in warmup mode."
 	warmingUp ifFalse: [

--- a/repository/SMark/SMarkCompiler.class.st
+++ b/repository/SMark/SMarkCompiler.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #SMarkCompiler,
-	#superclass : #SMarkSuite,
-	#category : #'SMark-Classic'
+	#name : 'SMarkCompiler',
+	#superclass : 'SMarkSuite',
+	#category : 'SMark-Classic',
+	#package : 'SMark',
+	#tag : 'Classic'
 }
 
-{ #category : #'script entry' }
+{ #category : 'script entry' }
 SMarkCompiler class >> defaultNumberOfIterations [
 	^ 50
 ]
 
-{ #category : #'script entry' }
+{ #category : 'script entry' }
 SMarkCompiler class >> defaultNumberOfProcesses [
 	^ 8
 ]
 
-{ #category : #'script entry' }
+{ #category : 'script entry' }
 SMarkCompiler class >> defaultProblemSize [
 	^ 30
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkCompiler >> benchCompiler [
 	"was Benchmark>>testCompiler"
 	self problemSize timesRepeat: [

--- a/repository/SMark/SMarkHarness.class.st
+++ b/repository/SMark/SMarkHarness.class.st
@@ -11,33 +11,34 @@ A typical call of the harness from the commandline would result in the following
 	SMarkHarness run: {'SMarkHarness'. 'SMarkLoops.benchIntLoop'. 1. 1. 5}
 "
 Class {
-	#name : #SMarkHarness,
-	#superclass : #Object,
-	#category : 'SMark'
+	#name : 'SMarkHarness',
+	#superclass : 'Object',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> defaultArgumentParser [
 	^ SMarkHarnessArgumentParser
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkHarness class >> defaultOutputDestination [
 	^ Smalltalk at:       #ScriptConsole
 	            ifAbsent: [SMarkReporter defaultOutputDestination]
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkHarness class >> defaultReporter [
 	^ SMarkReporter defaultReporter
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkHarness class >> defaultRunner [
 	^ SMarkSuite defaultRunner
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkHarness class >> execute: runner andReport: reporter [
 	runner reportConfiguration: self defaultOutputDestination.
 	runner execute.
@@ -46,7 +47,7 @@ SMarkHarness class >> execute: runner andReport: reporter [
 	reporter report.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkHarness class >> execute: aBenchmarkOrSuite using: aRunnerClass andReport: withAReporterClass [
 	| parsedBenchmarkOrSuite runner reporter |
 	
@@ -58,7 +59,7 @@ SMarkHarness class >> execute: aBenchmarkOrSuite using: aRunnerClass andReport: 
 	self execute: runner andReport: reporter.   
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> parseArguments: arguments [
 	| parser |
 	parser := self defaultArgumentParser new.
@@ -66,7 +67,7 @@ SMarkHarness class >> parseArguments: arguments [
 	^ parser parse: arguments.
 ]
 
-{ #category : #'script entry' }
+{ #category : 'script entry' }
 SMarkHarness class >> run: arguments [
 	"Executed from the command line using something similar to
 	 ./vm my.image SMarkHarness SMarkRunner SMarkReporter SMarkLoops\>\>benchIntLoop 1 1 5
@@ -87,7 +88,7 @@ SMarkHarness class >> run: arguments [
 	self execute: runner andReport: reporter. 
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> shouldShowUsage: arguments [
 	
 	arguments size < 2 ifTrue: [^ true ].
@@ -95,7 +96,7 @@ SMarkHarness class >> shouldShowUsage: arguments [
 	^ arguments anySatisfy: [:elem | (elem = '--help') or: [elem = '-?'] ].  
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> usage [
 	| usage |
 	"Example usage: SMarkHarness SMarkRunner SMarkReporter SMarkLoops.benchIntLoop 1 1 5"
@@ -112,7 +113,7 @@ SMarkHarness class >> usage [
 	self defaultOutputDestination print: usage.
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> usageBenchmarkParameters: usage [
 	^ usage,	' iterations         optional, number of times the benchmarks are repeated', String crlf,
 				' processes          optional, number of processes/threads used by the benchmarks', String crlf,
@@ -121,7 +122,7 @@ SMarkHarness class >> usageBenchmarkParameters: usage [
 
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> usageHeader [
 	| usage |
 	usage := 'SMark Benchmark Framework, version: ', self version, String crlf.
@@ -132,19 +133,19 @@ SMarkHarness class >> usageHeader [
 	^ usage
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> usageReporter: usage [
 	^ usage,	' reporter           optional, a SMarkReporter class that processes', String crlf,
 				'                              and displays the results', String crlf.
 	
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> usageRunner: usage [
 	^ usage, ' runner             optional, a SMarkRunner class that executes the benchmarks', String crlf.
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarness class >> version [
 	(Smalltalk classNamed: #ConfigurationOfBenchmarking)
 		ifNotNil: [:cfg |

--- a/repository/SMark/SMarkHarnessArgumentParser.class.st
+++ b/repository/SMark/SMarkHarnessArgumentParser.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #SMarkHarnessArgumentParser,
-	#superclass : #Object,
+	#name : 'SMarkHarnessArgumentParser',
+	#superclass : 'Object',
 	#instVars : [
 		'runner',
 		'reporter',
@@ -18,10 +18,11 @@ Class {
 		'suiteClass',
 		'harness'
 	],
-	#category : #SMark
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 SMarkHarnessArgumentParser >> determineBenchmarkParameters [
 	"Initialize with defaults, will be overwritten in case
 	 it is specified."
@@ -32,7 +33,7 @@ SMarkHarnessArgumentParser >> determineBenchmarkParameters [
 	self determineBenchmarkParametersFromArguments.
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 SMarkHarnessArgumentParser >> determineBenchmarkParametersFromArguments [
 	i := i + 1.
 	i <= numParams ifTrue: [
@@ -48,7 +49,7 @@ SMarkHarnessArgumentParser >> determineBenchmarkParametersFromArguments [
 	].
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 SMarkHarnessArgumentParser >> determineReporter [
 	(currentObj isKindOf: SMarkReporter)
 		ifFalse: [ reporter := harness defaultReporter new. ]
@@ -60,7 +61,7 @@ SMarkHarnessArgumentParser >> determineReporter [
 		].
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 SMarkHarnessArgumentParser >> determineRunner [
 	(currentObj isKindOf: SMarkRunner)
 		ifFalse: [ runner := harness defaultRunner new. ]
@@ -73,17 +74,17 @@ SMarkHarnessArgumentParser >> determineRunner [
 		].
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 SMarkHarnessArgumentParser >> determineSuiteOrBenchmark [
 	self parseBenchmarkOrSuite: current.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkHarnessArgumentParser >> harness: aHarness [
 	harness := aHarness
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkHarnessArgumentParser >> instructRunner [
 	suite := suiteClass new.
 	specificBenchmark ifNotNil: [
@@ -96,7 +97,7 @@ SMarkHarnessArgumentParser >> instructRunner [
 	runner problemSize: problemSize.
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 SMarkHarnessArgumentParser >> parse: argumentsArray [
 	arguments := argumentsArray.
 	numParams := arguments size.
@@ -117,7 +118,7 @@ SMarkHarnessArgumentParser >> parse: argumentsArray [
 	^ {runner. reporter}
 ]
 
-{ #category : #'argument parsing' }
+{ #category : 'argument parsing' }
 SMarkHarnessArgumentParser >> parseBenchmarkOrSuite: aBenchmarkOrSuite [
 	"Identify the benchmark suite or suite and benchmark method
 	 that should be executed. The string should be of the format 'Class>>benchName' or 'Class.benchName' for shell/bash compatibility.

--- a/repository/SMark/SMarkHarnessArgumentParserTest.class.st
+++ b/repository/SMark/SMarkHarnessArgumentParserTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #SMarkHarnessArgumentParserTest,
-	#superclass : #TestCase,
+	#name : 'SMarkHarnessArgumentParserTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'parser'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkHarnessArgumentParserTest >> setUp [
 	parser := SMarkHarnessArgumentParser new.
 	parser harness: SMarkHarness.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsOnlyBench [
 	| arguments runnerAndReporter runner reporter runOnly |
 	arguments := {#ignored. 'SMarkTestSuite.benchA' }.
@@ -32,7 +34,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsOnlyBench [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsOnlySuite [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkTestSuite' }.
@@ -49,7 +51,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsOnlySuite [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsReporterSuiteIterations [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkSimpleStatisticsReporter'. 'SMarkTestSuite'. '13'. }.
@@ -68,7 +70,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsReporterSuiteIterations [
 	self assert: 13 equals: runner iterations.	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsRunnerReporterSuiteIterations [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkTestRunner'. 'SMarkSimpleStatisticsReporter'. 'SMarkTestSuite'. '13'. }.
@@ -88,7 +90,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsRunnerReporterSuiteIteration
 	self assert: 13 equals: runner iterations.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsRunnerSuiteIterations [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkTestRunner'. 'SMarkTestSuite'. '13'. }.
@@ -107,7 +109,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsRunnerSuiteIterations [
 	self assert: 13 equals: runner iterations.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsSuiteAndIterations [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkTestSuite'. '13' }.
@@ -125,7 +127,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsSuiteAndIterations [
 	self assert: 13 equals: runner iterations.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsSuiteIterationsProcesses [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkTestSuite'. '13'. '91' }.
@@ -145,7 +147,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsSuiteIterationsProcesses [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseArgumentsSuiteIterationsProcessesProblemSize [
 	| arguments runnerAndReporter runner reporter |
 	arguments := {#ignored. 'SMarkTestSuite'. '13'. '91'. 'SSS' }.
@@ -166,7 +168,7 @@ SMarkHarnessArgumentParserTest >> testParseArgumentsSuiteIterationsProcessesProb
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessArgumentParserTest >> testParseBenchmarkOrSuite [
 	| example1 example2 example3 example4 example5 |
 	example1 := 'String>>findTokens:'.

--- a/repository/SMark/SMarkHarnessClassTest.class.st
+++ b/repository/SMark/SMarkHarnessClassTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SMarkHarnessClassTest,
-	#superclass : #TestCase,
-	#category : 'SMark-Tests'
+	#name : 'SMarkHarnessClassTest',
+	#superclass : 'TestCase',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkHarnessClassTest >> testShouldShowUsage [
 	| example1 example2 example3 example4 |
 	example1 := { #ignored. '--help' }.

--- a/repository/SMark/SMarkLoops.class.st
+++ b/repository/SMark/SMarkLoops.class.st
@@ -5,23 +5,25 @@ Example use:
   (SMarkLoops new runOnly: #benchFloatLoop) run: 10 
 "
 Class {
-	#name : #SMarkLoops,
-	#superclass : #SMarkSuite,
+	#name : 'SMarkLoops',
+	#superclass : 'SMarkSuite',
 	#instVars : [
 		'someInstVar'
 	],
 	#classVars : [
 		'ClassVarValue'
 	],
-	#category : 'SMark-Classic'
+	#category : 'SMark-Classic',
+	#package : 'SMark',
+	#tag : 'Classic'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkLoops class >> defaultProblemSize [
 	^ 50000
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchArrayAccess [
 	| i obj array |
 	
@@ -37,7 +39,7 @@ SMarkLoops >> benchArrayAccess [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchClassVarBinding [
 	| i r |
 	i := self problemSize.
@@ -49,7 +51,7 @@ SMarkLoops >> benchClassVarBinding [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchFloatLoop [
 	| a limit |
 	a := 1.23.
@@ -60,7 +62,7 @@ SMarkLoops >> benchFloatLoop [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchInstVarAccess [
 	| i r |
 	i := self problemSize.
@@ -72,7 +74,7 @@ SMarkLoops >> benchInstVarAccess [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchIntLoop [
 	| i |
 	i := self problemSize.
@@ -81,7 +83,7 @@ SMarkLoops >> benchIntLoop [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchSend [
 	| i r |
 	i := self problemSize.
@@ -91,7 +93,7 @@ SMarkLoops >> benchSend [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkLoops >> benchSendWithManyArguments [
 	| i r |
 	i := self problemSize.
@@ -101,10 +103,10 @@ SMarkLoops >> benchSendWithManyArguments [
 	].
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkLoops >> doNothing [
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkLoops >> doNothingA: p1 b: p2 c: p3 d: p4 e: p5 f: p6 g: p7 h: p8 i: p9 j: p10 [
 ]

--- a/repository/SMark/SMarkProfileRunner.class.st
+++ b/repository/SMark/SMarkProfileRunner.class.st
@@ -2,12 +2,13 @@
 This runner profiles the benchmarks for better analysis. Unlike the classical benchmark runner this one will not collect the results. Instead it will execute the benchmarks in the system profiler.
 "
 Class {
-	#name : #SMarkProfileRunner,
-	#superclass : #SMarkRunner,
-	#category : 'SMark'
+	#name : 'SMarkProfileRunner',
+	#superclass : 'SMarkRunner',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkProfileRunner class >> execute: aSuite selector: aBenchmarkSelector [
 	| runner |
 	runner := self new.
@@ -18,7 +19,7 @@ SMarkProfileRunner class >> execute: aSuite selector: aBenchmarkSelector [
 	^ runner
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkProfileRunner class >> execute: aSuite selector: aBenchmarkSelector iterations: nIterations [
 	| runner |
 	runner := self new.
@@ -30,25 +31,25 @@ SMarkProfileRunner class >> execute: aSuite selector: aBenchmarkSelector iterati
 	^ runner
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkProfileRunner >> execute [
 	"run all benchmnarks in a benchmark suite "
 	[ suite run ] timeProfile
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkProfileRunner >> execute: aSelector [
 	
 	[ self performBenchmark: aSelector ] timeProfile
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkProfileRunner >> initialize [
 	super initialize.
 	numIterations := 1.
 ]
 
-{ #category : #benchmarks }
+{ #category : 'benchmarks' }
 SMarkProfileRunner >> performBenchmark: aSelector [
 	currentBenchmark := aSelector.
 	
@@ -58,7 +59,7 @@ SMarkProfileRunner >> performBenchmark: aSelector [
 	currentBenchmark := nil.
 ]
 
-{ #category : #benchmarks }
+{ #category : 'benchmarks' }
 SMarkProfileRunner >> timedBenchmarkExecution: aSelector [
 	suite perform: aSelector
 ]

--- a/repository/SMark/SMarkReporter.class.st
+++ b/repository/SMark/SMarkReporter.class.st
@@ -11,33 +11,34 @@ Example:
 	f contents
 "
 Class {
-	#name : #SMarkReporter,
-	#superclass : #Object,
+	#name : 'SMarkReporter',
+	#superclass : 'Object',
 	#instVars : [
 		'runner',
 		'stream'
 	],
-	#category : 'SMark'
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkReporter class >> defaultOutputDestination [
 	^ ScriptConsole
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkReporter class >> defaultReporter [
 	^ SMarkSimpleStatisticsReporter
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter class >> reportFor: aRunner [
 	^ self
 		reportFor: aRunner
 		on: self defaultOutputDestination.
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter class >> reportFor: aRunner on: aStream [
 	| reporter |
 	reporter := self new
@@ -47,41 +48,41 @@ SMarkReporter class >> reportFor: aRunner on: aStream [
 	^ reporter.
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter >> benchmarkFooter: aName [
-	stream cr.
+	stream cr; flush.
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter >> benchmarkHeader: aName [
 	stream << 'Benchmark ' << (aName asString); cr.
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter >> footer [
 	"No output at the moment"
 	^ self
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter >> header [
 	| suiteName |
 	suiteName := runner suite class name asString.
 	stream << 'Report for: ' << suiteName; cr.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkReporter >> initialize [
 	super initialize.
 	stream := self class defaultOutputDestination.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkReporter >> outputStream: aStream [
 	stream := aStream  
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkReporter >> report [
 	self header.
 	
@@ -95,14 +96,14 @@ SMarkReporter >> report [
 	^ self
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkReporter >> reportAllRuns: aListOfResults of: benchmark [
 	aListOfResults do: [:result |
 		result criteria keysAndValuesDo: [:benchName :timer |
 			stream << benchName << ': ' << (timer totalTime asString, 'ms'); cr.]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkReporter >> runner: aRunner [
 	runner := aRunner.
 ]

--- a/repository/SMark/SMarkReporterTest.class.st
+++ b/repository/SMark/SMarkReporterTest.class.st
@@ -9,8 +9,16 @@ Class {
 	#tag : 'Tests'
 }
 
+{ #category : 'tests' }
+SMarkReporterTest >> outputFile [
+
+	^ 'report.txt' asFileReference
+]
+
 { #category : 'running' }
 SMarkReporterTest >> setUp [
+
+	super setUp.
 	runner := SMarkTestRunnerSuiteForAutosizing run.
 ]
 
@@ -20,6 +28,13 @@ SMarkReporterTest >> string: str includes: subStr [
 	(str respondsTo: #includesSubstring:)
 		ifTrue:  [ ^ str includesSubstring: subStr ] "2.0"
 		ifFalse: [ ^ str includesSubString: subStr ] "1.4"
+]
+
+{ #category : 'running' }
+SMarkReporterTest >> tearDown [ 
+
+	self outputFile ensureDelete.
+	super tearDown.
 ]
 
 { #category : 'tests' }
@@ -50,4 +65,19 @@ SMarkReporterTest >> testConvenienceReportOnRunner [
 	
 	self assert: (self string: out includes: 'Small').
 	self assert: (self string: out includes: 'Big').
+]
+
+{ #category : 'tests' }
+SMarkReporterTest >> testReportOnFileWriteContents [
+	| stream outputContents |
+
+	stream := self outputFile writeStream.
+	runner := SMarkTestAutosizeRunner execute: SMarkTestRunnerSuiteForAutosizing new.
+	"Check whether it reported as expected"
+	SMarkReporter reportFor: runner on: stream.
+	
+	outputContents := self outputFile readStream contents.
+
+	self assert: (self string: outputContents includes: 'Small').
+	self assert: (self string: outputContents includes: 'Big').
 ]

--- a/repository/SMark/SMarkReporterTest.class.st
+++ b/repository/SMark/SMarkReporterTest.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #SMarkReporterTest,
-	#superclass : #TestCase,
+	#name : 'SMarkReporterTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'runner'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkReporterTest >> setUp [
 	runner := SMarkTestRunnerSuiteForAutosizing run.
 ]
 
-{ #category : #'compatibility Pharo 1.4 vs. 2.0' }
+{ #category : 'compatibility Pharo 1.4 vs. 2.0' }
 SMarkReporterTest >> string: str includes: subStr [
 	"To be compatible with Pharo 1.4 and 2.0"
 	(str respondsTo: #includesSubstring:)
@@ -20,7 +22,7 @@ SMarkReporterTest >> string: str includes: subStr [
 		ifFalse: [ ^ str includesSubString: subStr ] "1.4"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkReporterTest >> testContentOfStream [
 	"Hm, how to test that robustly?"
 	| reporter stream out |
@@ -33,7 +35,7 @@ SMarkReporterTest >> testContentOfStream [
 	self assert: (self string: out includes: 'Big').
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkReporterTest >> testConvenienceReportOnRunner [
 	| stream out |
 	stream := TextStream on: String new.

--- a/repository/SMark/SMarkResult.class.st
+++ b/repository/SMark/SMarkResult.class.st
@@ -8,53 +8,54 @@ A benchmark result is characterized by:
 A benchmark can produced multiple resuts for different criteria. The standard criterion is #total.
 "
 Class {
-	#name : #SMarkResult,
-	#superclass : #Object,
+	#name : 'SMarkResult',
+	#superclass : 'Object',
 	#instVars : [
 		'time',
 		'benchName',
 		'suite',
 		'criteria'
 	],
-	#category : 'SMark'
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> benchmarkName [
 	^ benchName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> benchmarkName: aString [
 	benchName := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> criteria [
 	^ criteria
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> criteria: aCollectionOfTimers [
 	criteria := aCollectionOfTimers
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> suite [
 	^ suite
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> suite: aBenchmarkSuite [
 	suite := aBenchmarkSuite
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> total [
 	^ time
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkResult >> total: aTime [
 	time := aTime
 ]

--- a/repository/SMark/SMarkResultTest.class.st
+++ b/repository/SMark/SMarkResultTest.class.st
@@ -3,38 +3,40 @@ This test specifies the data stored in a result object.
 The result object does not actually provide behavior on its own.
 "
 Class {
-	#name : #SMarkResultTest,
-	#superclass : #TestCase,
+	#name : 'SMarkResultTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'result'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkResultTest >> setUp [
 	| runner |
 	runner := SMarkTestRunner execute: SMarkTestRunnerSuite new.
 	result := (runner results at: #DoNothing) at: 1.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkResultTest >> testBenchmarkName [
 	self assert: (result benchmarkName isKindOf: String)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkResultTest >> testCriteria [
 	self assert: (result criteria respondsTo: #at:).
 	self assert: (result criteria size > 0).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkResultTest >> testSuite [
 	self assert: result suite notNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkResultTest >> testTotal [
 	self assert: (result total isKindOf: Number)
 ]

--- a/repository/SMark/SMarkRunner.class.st
+++ b/repository/SMark/SMarkRunner.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #SMarkRunner,
-	#superclass : #Object,
+	#name : 'SMarkRunner',
+	#superclass : 'Object',
 	#instVars : [
 		'numIterations',
 		'suite',
@@ -11,30 +11,31 @@ Class {
 		'problemSize',
 		'numProcesses'
 	],
-	#category : #SMark
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkRunner class >> defaultNumberOfIterations [
 	^ 1
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkRunner class >> defaultNumberOfProcesses [
 	^ 1
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkRunner class >> defaultTimer [
 	^ SMarkTimer
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner class >> execute: aSuite [
 	^ self execute: aSuite with: 1.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner class >> execute: aSuite problemSize: problemSize [
 	| runner |
 	runner := self new.
@@ -45,7 +46,7 @@ SMarkRunner class >> execute: aSuite problemSize: problemSize [
 	^ runner
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner class >> execute: aSuite with: nIterations [
 	| runner |
 	runner := self new.
@@ -56,7 +57,7 @@ SMarkRunner class >> execute: aSuite with: nIterations [
 	^ runner
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkRunner >> createTimer: name [
 	"Create and register a new timer for the current benchmark"
 	| timer |
@@ -69,7 +70,7 @@ SMarkRunner >> createTimer: name [
 	^ timer.
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SMarkRunner >> execute [
 	
 	self runSuite.
@@ -78,7 +79,7 @@ SMarkRunner >> execute [
 	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkRunner >> initialize [
 	super initialize.
 	numIterations := self class defaultNumberOfIterations.
@@ -86,23 +87,23 @@ SMarkRunner >> initialize [
 	results := Dictionary new.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> iterations [
 	^ numIterations
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> iterations: anInteger [
 	numIterations := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> numberOfIterations [
 
 	^ numIterations ifNil: [ self class defaultNumberOfIterations ]
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner >> performBenchmark: aSelector [
 	currentBenchmark := aSelector.
 	
@@ -116,7 +117,7 @@ SMarkRunner >> performBenchmark: aSelector [
 	^ results at: (suite benchmarkNameForSelector: aSelector)
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner >> postBenchmark [
 
 	"Hook for subclasses.
@@ -125,25 +126,25 @@ SMarkRunner >> postBenchmark [
 	currentBenchmark := nil.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner >> preBenchmark [
 
 	"Hook for subclasses.
 	Executed before all iterations"
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SMarkRunner >> printOn: aStream [
 	^ self reportOn: aStream.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> problemSize [
 	<omniUnenforced> "Hint for the OMOP that it is part of the meta infrastructure"
 	^ problemSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> problemSize: aValue [
 	"Do some conversion to make it easier for the benchmarks"
 	(aValue isString and: [aValue isAllDigits]) ifTrue: [
@@ -154,19 +155,19 @@ SMarkRunner >> problemSize: aValue [
 	problemSize := aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> processes [
 	"The standard runner does use only a single process, but in case a benchmark supports parallelism it can query for the intended degree of parallelism"
 	^ numProcesses
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> processes: anInt [
 	"The standard runner does use only a single process, but a benchmark can use that to do its own parallelism"
 	numProcesses := anInt
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkRunner >> recordResults: timer for: aSelector [
 	| result name |
 	name := suite benchmarkNameForSelector: aSelector.
@@ -180,13 +181,13 @@ SMarkRunner >> recordResults: timer for: aSelector [
 	(results at: name ifAbsentPut: [OrderedCollection new]) add: result.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> report [
 	SMarkReporter defaultReporter reportFor: self.  
 	
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkRunner >> reportConfiguration: aStream [
 	aStream << 'Runner Configuration:';cr.
 	aStream << ('  iterations: ', numIterations asString); cr.
@@ -195,18 +196,18 @@ SMarkRunner >> reportConfiguration: aStream [
 
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkRunner >> reportOn: aStream [
 	SMarkReporter defaultReporter reportFor: self on: aStream  
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> results [
 	^ results
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner >> runBaseBenchmark [
 	"In certain sitatuations it is one wants a baseline that is incooprated in all 
 	 benchmark results to be substracted from the final values.
@@ -219,7 +220,7 @@ SMarkRunner >> runBaseBenchmark [
 	^ self performBenchmark: #baseBenchmark.
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SMarkRunner >> runSuite [
 
 	"Hook for subclasses, private API, do not call directly."
@@ -227,18 +228,18 @@ SMarkRunner >> runSuite [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> suite [
 	^ suite
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkRunner >> suite: aBenchmarkSuite [
 	suite := aBenchmarkSuite.
 	suite runner: self.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkRunner >> timedBenchmarkExecution: aSelector [
 	"Will do a timed execution of the benchmark and return the result timer"
 	| timer result |

--- a/repository/SMark/SMarkRunnerTest.class.st
+++ b/repository/SMark/SMarkRunnerTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SMarkRunnerTest,
-	#superclass : #TestCase,
-	#category : 'SMark-Tests'
+	#name : 'SMarkRunnerTest',
+	#superclass : 'TestCase',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkRunnerTest >> runnerClass [
 	^ SMarkTestRunner
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testBaseBenchmark [
 	"Ensure the base benchmark is executed when available"
 	
@@ -19,7 +21,7 @@ SMarkRunnerTest >> testBaseBenchmark [
 	self assert: runner baseBenchmarkExecuted  
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testBaseBenchmarkNone [
 	"Ensure that not having a base benchmark does not pose a problem"
 
@@ -29,7 +31,7 @@ SMarkRunnerTest >> testBaseBenchmarkNone [
 	self deny: runner baseBenchmarkExecuted  
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testBenchmarkWithMultipleCriteraTimers [
 	"Check whether the benchmark benchWithMultipleCriteria, really results in different unrelated timings"
 	| runner result |
@@ -50,7 +52,7 @@ SMarkRunnerTest >> testBenchmarkWithMultipleCriteraTimers [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testClassExecute [
 	| runner |
 	runner := self runnerClass execute: SMarkTestSuiteWithBaseBenchmark new.
@@ -58,7 +60,7 @@ SMarkRunnerTest >> testClassExecute [
 	self assert: (runner isKindOf: self runnerClass).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testExecute [
 	"Ensure all benchmarks are run, including the baseBenchmark and the results are returned"
 	| runner results performedBenchmarks |
@@ -75,7 +77,7 @@ SMarkRunnerTest >> testExecute [
 	self assert: (((results at: #baseBenchmark) at: 1) isKindOf: SMarkResult).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testIterations [
 	| runner |
 	" simple scenario should default to 1 run for now "
@@ -98,7 +100,7 @@ SMarkRunnerTest >> testIterations [
 	self assert: 10 equals: runner countWasExecuted.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testPerformBenchmark [
 	"Ensure that performBenchmark executes all the defined #bench methods, but for instance not #Bench"
 	
@@ -114,7 +116,7 @@ SMarkRunnerTest >> testPerformBenchmark [
 	self deny: (performedBenchmarks includes: #BenchShouldNotBeExecuted).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testResultStructure [
 	| runner results resultA resultB suite |
 	suite := SMarkTestSuite new.
@@ -145,7 +147,7 @@ SMarkRunnerTest >> testResultStructure [
 	"Testing for multi-criteria results somewhere else"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkRunnerTest >> testTimer [
 	"Simple test whether a timer is created and it is from the expected class.
 	 This test is very basic, other tests like testBenchmarkWithMultipleCirteria* need to cover the rest"

--- a/repository/SMark/SMarkSimpleStatisticsReporter.class.st
+++ b/repository/SMark/SMarkSimpleStatisticsReporter.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #SMarkSimpleStatisticsReporter,
-	#superclass : #SMarkReporter,
-	#category : 'SMark'
+	#name : 'SMarkSimpleStatisticsReporter',
+	#superclass : 'SMarkReporter',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #statistics }
+{ #category : 'statistics' }
 SMarkSimpleStatisticsReporter >> confidenceVariance: times [
 	| numMeasurements |
 	numMeasurements := times size.
@@ -16,7 +17,7 @@ SMarkSimpleStatisticsReporter >> confidenceVariance: times [
 	^ (self studentsTConfidenceFactorFor: numMeasurements) * (times stdev) / (numMeasurements asFloat sqrt)
 ]
 
-{ #category : #statistics }
+{ #category : 'statistics' }
 SMarkSimpleStatisticsReporter >> gaussianConfidenceFactor [
 	"used for large probe counts >= 30"
 	"1 ~ 68.27%"
@@ -25,7 +26,7 @@ SMarkSimpleStatisticsReporter >> gaussianConfidenceFactor [
 	^ 1.644853626951
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkSimpleStatisticsReporter >> reportAllRuns: aListOfResults of: benchmark [
 	| criteria |
 
@@ -39,7 +40,7 @@ SMarkSimpleStatisticsReporter >> reportAllRuns: aListOfResults of: benchmark [
 	].
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkSimpleStatisticsReporter >> reportResult: aResultsArray for: aCriterion of: benchmark [
 	| convidenceVariance significantDigits |
 
@@ -63,13 +64,13 @@ SMarkSimpleStatisticsReporter >> reportResult: aResultsArray for: aCriterion of:
 	convidenceVariance printOn: stream showingDecimalPlaces: significantDigits.
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkSimpleStatisticsReporter >> resultsFor: aCriterion from: aListOfResults [
 	^aListOfResults collect: [:result | (result criteria at: aCriterion) totalTime]
 	
 ]
 
-{ #category : #statistics }
+{ #category : 'statistics' }
 SMarkSimpleStatisticsReporter >> significantDigits: confidenceVariance [
 	confidenceVariance = 0 
 		ifTrue: [ ^ 2].
@@ -80,7 +81,7 @@ SMarkSimpleStatisticsReporter >> significantDigits: confidenceVariance [
 	^ 1 - (confidenceVariance log floor)
 ]
 
-{ #category : #statistics }
+{ #category : 'statistics' }
 SMarkSimpleStatisticsReporter >> studentsTConfidenceFactorFor: aNumberOfMeasurements [
 	"used for small probe counts < 30"
 	"the students T distribution sucks to calculate since the value depends on the probeCout"
@@ -121,7 +122,7 @@ SMarkSimpleStatisticsReporter >> studentsTConfidenceFactorFor: aNumberOfMeasurem
 	
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkSimpleStatisticsReporter >> totalResultsFor: aListOfResults [
 	^ aListOfResults collect: [:result | result total]
 	

--- a/repository/SMark/SMarkSlopstone.class.st
+++ b/repository/SMark/SMarkSlopstone.class.st
@@ -35,16 +35,18 @@ Bruce Samuelson
 
 "
 Class {
-	#name : #SMarkSlopstone,
-	#superclass : #SMarkSuite,
+	#name : 'SMarkSlopstone',
+	#superclass : 'SMarkSuite',
 	#instVars : [
 		'obj',
 		'o'
 	],
-	#category : #'SMark-Classic'
+	#category : 'SMark-Classic',
+	#package : 'SMark',
+	#tag : 'Classic'
 }
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSlopstone >> benchStone [
 	"Using the SlopStone benchmarks, but not doing the
 	 old style Stone performance number reporting"
@@ -66,12 +68,12 @@ SMarkSlopstone >> benchStone [
 
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkSlopstone >> defaultProblemSize [
 	^ 1
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doBlockValue [
 	[] value. [] value. [] value. [] value. [] value. [] value. [] value.
 	[] value. [] value. [] value. [] value. [] value. [] value. [] value.
@@ -83,13 +85,13 @@ SMarkSlopstone >> doBlockValue [
 	[] value. [] value. [] value. [] value. [] value. [] value. [] value
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doFloatAdd [
 	1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+
 	1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0+1.0
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doIntAdd [
 	1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+
 	1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+
@@ -100,12 +102,12 @@ SMarkSlopstone >> doIntAdd [
 	1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doObjectCopy [
 	o copy copy copy copy copy copy copy copy copy copy
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doObjectCreation [
 	obj new. obj new. obj new. obj new. obj new.
 	obj new. obj new. obj new. obj new. obj new.
@@ -113,7 +115,7 @@ SMarkSlopstone >> doObjectCreation [
 	obj new. obj new. obj new. obj new. obj new
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doPerform [
 	o perform: #yourself. o perform: #yourself. o perform: #yourself.
 	o perform: #yourself. o perform: #yourself. o perform: #yourself.
@@ -127,7 +129,7 @@ SMarkSlopstone >> doPerform [
 	o perform: #yourself. o perform: #yourself. o perform: #yourself
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSlopstone >> doStringAccess [
 	'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1.
 	'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1.
@@ -141,7 +143,7 @@ SMarkSlopstone >> doStringAccess [
 	'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1. 'a' at: 1
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSlopstone >> problemSize [
 	<omniUnenforced> "Hint for the OMOP that it is part of the meta infrastructure"
 	| ps |
@@ -152,7 +154,7 @@ SMarkSlopstone >> problemSize [
 	^ ps
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSlopstone >> readme [
    "STEFAN: use the original benchmarks, but do not use original way
             of reporting results. Rely on the SMark reporting instead."
@@ -230,7 +232,7 @@ SMarkSlopstone >> readme [
 	^ self
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 SMarkSlopstone >> setUp [
 	obj := Object.
 ]

--- a/repository/SMark/SMarkSmopstone.class.st
+++ b/repository/SMark/SMarkSmopstone.class.st
@@ -23,8 +23,8 @@ originak code by
 
 "
 Class {
-	#name : #SMarkSmopstone,
-	#superclass : #SMarkSuite,
+	#name : 'SMarkSmopstone',
+	#superclass : 'SMarkSuite',
 	#instVars : [
 		'ordCollectionFact',
 		'intervalFact',
@@ -34,10 +34,12 @@ Class {
 		'setFact',
 		'pointFact'
 	],
-	#category : 'SMark-Classic'
+	#category : 'SMark-Classic',
+	#package : 'SMark',
+	#tag : 'Classic'
 }
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSmopstone >> benchStone [
 	| n primes strings set |
 	
@@ -55,12 +57,12 @@ SMarkSmopstone >> benchStone [
 	self sorcerersApprentice: n.
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkSmopstone >> defaultProblemSize [
 	^ 80
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> fractonacci: n [ 
 	"Return something like the fibonacci function of n but
 	using fractional numbers rather than whole ones. The
@@ -80,7 +82,7 @@ SMarkSmopstone >> fractonacci: n [
 		ifFalse: [1]
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> primesUpTo: n [
 	"modified by nishis"
 
@@ -105,7 +107,7 @@ SMarkSmopstone >> primesUpTo: n [
 	^ lowPrimes , highPrimes
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSmopstone >> problemSize [
 	<omniUnenforced> "Hint for the OMOP that it is part of the meta infrastructure"
 	| ps |
@@ -116,7 +118,7 @@ SMarkSmopstone >> problemSize [
 	^ ps
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSmopstone >> readme [
    "STEFAN: use the original benchmarks, but do not use original way
             of reporting results. Rely on the SMark reporting instead."
@@ -214,7 +216,7 @@ SMarkSmopstone >> readme [
 	^ self
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> setFrom: collection [
 	"Form a set from collection and return it.
 
@@ -228,7 +230,7 @@ SMarkSmopstone >> setFrom: collection [
 	^ setFact withAll: collection
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkSmopstone >> setUp [
 	ordCollectionFact := OrderedCollection.
 	intervalFact      := Interval.
@@ -239,7 +241,7 @@ SMarkSmopstone >> setUp [
 	pointFact         := Point.
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> sorcerersApprentice: m [
 	"modified by nishis"
 
@@ -337,7 +339,7 @@ SMarkSmopstone >> sorcerersApprentice: m [
 	^counts
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> sort: collection [
 	"Form a sorted collection from collection and return it.
 
@@ -348,7 +350,7 @@ SMarkSmopstone >> sort: collection [
 	^collection as: sortedColFact
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> streamTestsOn: integers [ 
 	"modified by nishis"
 	"Test steaming operations on the collection of integers. 
@@ -392,7 +394,7 @@ SMarkSmopstone >> streamTestsOn: integers [
 	integers = floats ifFalse: [self error: 'Numbers do not compare.']
 ]
 
-{ #category : #'stone benchmarks' }
+{ #category : 'stone benchmarks' }
 SMarkSmopstone >> stringsUpTo: n [ 
 	"Return a collection of strings representing the integers from 1 
 	to n with their digits reversed. 

--- a/repository/SMark/SMarkSuite.class.st
+++ b/repository/SMark/SMarkSuite.class.st
@@ -17,16 +17,17 @@ To get an example print the result of the following expression:
 
 "
 Class {
-	#name : #SMarkSuite,
-	#superclass : #Object,
+	#name : 'SMarkSuite',
+	#superclass : 'Object',
 	#instVars : [
 		'runner',
 		'selectedBenchmarks'
 	],
-	#category : #SMark
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> benchmarkForSelector: aSelector [
 
 	"Returns a single benchmark for the corresponding selector"
@@ -37,24 +38,24 @@ SMarkSuite class >> benchmarkForSelector: aSelector [
 		yourself
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> benchmarkParameters [
 
   ^ ParametrizedTestMatrix new
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkSuite class >> defaultProblemSize [
 	^ nil
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkSuite class >> defaultRunner [
 	^ self onCog: [SMarkCogRunner]
 	       else:  [SMarkRunner]
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> isAbstractClass [
 	"This is a hack that is necessary in Squeak since it does not provide #isAbstractClass.
 	 Actually this class is supposed to be abstract, but well, inheritance..."
@@ -62,50 +63,50 @@ SMarkSuite class >> isAbstractClass [
 	^ false
 ]
 
-{ #category : #'platform support' }
+{ #category : 'platform support' }
 SMarkSuite class >> onCog: cogSpecificBlock else: general [
 	^ (Smalltalk vm isRunningCogit)
 		ifTrue:  [cogSpecificBlock value]
 		ifFalse: [general value]
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkSuite class >> profile: aSelector [
 	^ self profileRunner 
 		execute: self new selector: aSelector.
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkSuite class >> profile: aSelector iterations: nIterations [
 	^ self profileRunner 
 		execute: self new selector: aSelector iterations: nIterations.
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkSuite class >> profileAll [
 	^ self profileRunner 
 		execute: self new.
 ]
 
-{ #category : #profiling }
+{ #category : 'profiling' }
 SMarkSuite class >> profileRunner [
 	^ SMarkProfileRunner
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> run [
 	"Execute the suite one time."
 	^ self defaultRunner execute: self new.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> run: nIterations [
 	"Execute the suite a given number of iterations."
 	
 	^ self defaultRunner execute: self new with: nIterations.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> runOnly: aSelector [
   "aSelector should refer to a benchmark method.
    Example:
@@ -114,14 +115,14 @@ SMarkSuite class >> runOnly: aSelector [
   ^ self defaultRunner execute: (self new runOnly: aSelector)
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite class >> runOnly: aSelector iterations: anInteger [
 	"Execute only the bench name aSelector from the suite."
 	
 	^ self defaultRunner execute: (self new runOnly: aSelector) with: anInteger
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkSuite >> benchmarkNameForSelector: selector [
 
 	"Extracts the actual name of the benchmark from the selector"
@@ -137,7 +138,7 @@ SMarkSuite >> benchmarkNameForSelector: selector [
 		^ benchName, stream contents ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkSuite >> cleanUpInstanceVariables [
 	"Make sure all variables that are 'user variables' get cleaned"
 	
@@ -145,30 +146,30 @@ SMarkSuite >> cleanUpInstanceVariables [
 		self instVarNamed: name put: nil ]
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> currentBenchmarkParameters [ 
 
 	^ (self class benchmarkParameters selectors collect: [ :selector | (selector -> (self instVarNamed: selector)) ]) asDictionary
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkSuite >> instanceVariablesToPreserve [
 	^ { #runner. self paramInstanceVariables } flattened
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkSuite >> paramInstanceVariables [
 
 	^ self class benchmarkParameters selectors.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkSuite >> performBenchmarkSelector: aSelector [
 
 	^ self perform: aSelector
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> performBenchmarks [
 
 	| potentialBenchmarkSelectors |
@@ -181,7 +182,7 @@ SMarkSuite >> performBenchmarks [
 			runner performBenchmark: selector ] ]
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> performCustomSelector: aSelector with: aPrefix [
 	| customSelector |
 	customSelector := (aPrefix, aSelector capitalized) asSymbol.
@@ -189,7 +190,7 @@ SMarkSuite >> performCustomSelector: aSelector with: aPrefix [
 		self perform: customSelector].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> problemSize [
 	<omniUnenforced> "Hint for the OMOP that it is part of the meta infrastructure"
 	runner             ifNil: [^ self class defaultProblemSize].
@@ -197,13 +198,13 @@ SMarkSuite >> problemSize [
 	^ runner problemSize
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> processResult: anObject withTimer: aSMarkTimer [
 	"subclass responsability. You can verify your results here, or do things with the timer."
 	^self.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> run [
 	"Executes all the benchmarks in the suite, 
 	 coordinating with the runner when necessary"
@@ -220,7 +221,7 @@ SMarkSuite >> run [
 	].
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> runBenchmark: aSelector [
 	
 	[self setUp.
@@ -231,33 +232,33 @@ SMarkSuite >> runBenchmark: aSelector [
 		self cleanUpInstanceVariables]
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> runOnly: aSymbol [
 	selectedBenchmarks := IdentitySet newFrom: { aSymbol }.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkSuite >> runner [
 	^ runner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkSuite >> runner: aRunner [
 	runner := aRunner.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkSuite >> selectedBenchmarks [
 	^ selectedBenchmarks
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkSuite >> setUp [
 	"It is the subclass' responsibility to set up the necessary environment for a benchmark"
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SMarkSuite >> shouldRunSelector: selector [
 	"Tells whether the given selector is in the form bench*, and thus is a benchmark that should be executed."
 	
@@ -265,7 +266,7 @@ SMarkSuite >> shouldRunSelector: selector [
 	^ selector beginsWith: #bench
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkSuite >> tearDown [
 	"It is the subclass' responsibility to clean up the environment after a benchmark"
 	^ self

--- a/repository/SMark/SMarkSuiteTest.class.st
+++ b/repository/SMark/SMarkSuiteTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #SMarkSuiteTest,
-	#superclass : #TestCase,
+	#name : 'SMarkSuiteTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'didSetUpBenchB',
 		'didTearDownBenchC'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testBenchmarkNameForSelector [
 	| suite |
 	suite := SMarkSuite new.
@@ -20,7 +22,7 @@ SMarkSuiteTest >> testBenchmarkNameForSelector [
 	self assert: (suite benchmarkNameForSelector: #BenchSomeThing) equals: #BenchSomeThing.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testClassRun [
 	| runner |
 	
@@ -29,7 +31,7 @@ SMarkSuiteTest >> testClassRun [
 	self deny: runner results isNil    
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testCleanUpInstanceVariables [
 	| suite |
 	suite := SMarkTestSuite new.
@@ -49,7 +51,7 @@ SMarkSuiteTest >> testCleanUpInstanceVariables [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testCustomSetUp [
 	| suite runner |
 	
@@ -59,7 +61,7 @@ SMarkSuiteTest >> testCustomSetUp [
 	self assert: runner hasSetUpBenchB
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testCustomTearDown [
 	| suite runner |
 	suite := SMarkTestSuite new.
@@ -68,7 +70,7 @@ SMarkSuiteTest >> testCustomTearDown [
 	self assert: runner hasTearDownBenchC.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testSetUp [
 	| suite runner |
 	suite := SMarkTestSuite new.
@@ -91,7 +93,7 @@ SMarkSuiteTest >> testSetUp [
 	self assert: 4 equals: runner setUpCount.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testSetupAndTeaddownCalledForEveryBenchForEveryIteration [
 	| suite runner |
 
@@ -118,7 +120,7 @@ SMarkSuiteTest >> testSetupAndTeaddownCalledForEveryBenchForEveryIteration [
 	self assert: (4 * 10) equals: runner tearDownCount.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testShouldRunSelector [
 	| suite |
 	suite := SMarkSuite new.
@@ -130,7 +132,7 @@ SMarkSuiteTest >> testShouldRunSelector [
 	self deny: (suite shouldRunSelector: #BenchSomeThing).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkSuiteTest >> testTearDown [
 	| suite runner |
 	suite := SMarkTestSuite new.

--- a/repository/SMark/SMarkTest.class.st
+++ b/repository/SMark/SMarkTest.class.st
@@ -2,12 +2,14 @@
 A general test to ensure the overall framework works as expected.
 "
 Class {
-	#name : #SMarkTest,
-	#superclass : #TestCase,
-	#category : 'SMark-Tests'
+	#name : 'SMarkTest',
+	#superclass : 'TestCase',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkTest >> setUp [
 	"Necessary for Squeak 4.2 compatibility, since method anotations are not supported in the base image."
 	(self respondsTo:  #timeout:) ifTrue: [
@@ -15,7 +17,7 @@ SMarkTest >> setUp [
 	].
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkTest >> testAllBenchmarksForReturningThemSelf [
 	"This is a regression test to ensure that the old behavior worked in the first place"
 	| allSuites |
@@ -34,7 +36,7 @@ SMarkTest >> testAllBenchmarksForReturningThemSelf [
 	].
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkTest >> testBasicRun [
 	| runner results benchResult result |
 	

--- a/repository/SMark/SMarkTestAutosizeRunner.class.st
+++ b/repository/SMark/SMarkTestAutosizeRunner.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #SMarkTestAutosizeRunner,
-	#superclass : #SMarkAutosizeRunner,
+	#name : 'SMarkTestAutosizeRunner',
+	#superclass : 'SMarkAutosizeRunner',
 	#instVars : [
 		'performedBenchmarks',
 		'notifyRunnerWasExecuted',
@@ -10,50 +10,52 @@ Class {
 		'didSetUpBenchB',
 		'baseBenchmarkExecuted'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> baseBenchmarkExecuted [
 	^ baseBenchmarkExecuted
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> countSetUpInvoke [
 	setUpCount := setUpCount + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> countTearDownInvoke [
 	tearDownCount := tearDownCount + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> countWasExecuted [
 	^ notifyRunnerWasExecuted 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> didPerform: aSymbol [
 	performedBenchmarks add: aSymbol.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> didRunBaseBenchmark [
 	baseBenchmarkExecuted := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> didSetUpBenchB [
 	didSetUpBenchB := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> didTearDownBenchC [
 	didTearDownBenchC := true.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkTestAutosizeRunner >> initialize [
 	super initialize.
 
@@ -69,22 +71,22 @@ SMarkTestAutosizeRunner >> initialize [
 	targetTime := 50.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> isNotifyRunnerWasExecutedSet [
 	^ notifyRunnerWasExecuted
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> notifyRunnerWasExecuted [
 	notifyRunnerWasExecuted := notifyRunnerWasExecuted + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> performedBenchmarks [
 	^ performedBenchmarks
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestAutosizeRunner >> setUp [
 	notifyRunnerWasExecuted := false
 ]

--- a/repository/SMark/SMarkTestRunner.class.st
+++ b/repository/SMark/SMarkTestRunner.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #SMarkTestRunner,
-	#superclass : #SMarkRunner,
+	#name : 'SMarkTestRunner',
+	#superclass : 'SMarkRunner',
 	#instVars : [
 		'performedBenchmarks',
 		'notifyRunnerWasExecuted',
@@ -10,60 +10,62 @@ Class {
 		'didSetUpBenchB',
 		'baseBenchmarkExecuted'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> baseBenchmarkExecuted [
 	^ baseBenchmarkExecuted
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> countSetUpInvoke [
 	setUpCount := setUpCount + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> countTearDownInvoke [
 	tearDownCount := tearDownCount + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> countWasExecuted [
 	^ notifyRunnerWasExecuted 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> didPerform: aSymbol [
 	performedBenchmarks add: aSymbol.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> didRunBaseBenchmark [
 	baseBenchmarkExecuted := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> didSetUpBenchB [
 	didSetUpBenchB := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> didTearDownBenchC [
 	didTearDownBenchC := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> hasSetUpBenchB [
 	^ didSetUpBenchB.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> hasTearDownBenchC [
 	^ didTearDownBenchC
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkTestRunner >> initialize [
 	super initialize.
 
@@ -76,32 +78,32 @@ SMarkTestRunner >> initialize [
 	performedBenchmarks := OrderedCollection new.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> isNotifyRunnerWasExecutedSet [
 	^ notifyRunnerWasExecuted
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> notifyRunnerWasExecuted [
 	notifyRunnerWasExecuted := notifyRunnerWasExecuted + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> performedBenchmarks [
 	^ performedBenchmarks
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> setUp [
 	notifyRunnerWasExecuted := false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> setUpCount [
 	^ setUpCount
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunner >> tearDownCount [
 	^ tearDownCount
 ]

--- a/repository/SMark/SMarkTestRunnerSuite.class.st
+++ b/repository/SMark/SMarkTestRunnerSuite.class.st
@@ -2,24 +2,26 @@
 This is a benchmark suite used to test the benchmark runner
 "
 Class {
-	#name : #SMarkTestRunnerSuite,
-	#superclass : #SMarkSuite,
-	#category : 'SMark-Tests'
+	#name : 'SMarkTestRunnerSuite',
+	#superclass : 'SMarkSuite',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuite class >> isAbstractClass [
 	"This is more like a hack, but we do not want to execute this as a benchmark"
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuite >> benchDoNothing [
 	"Just a dummy that should be executed and result in some measured value"
 	^ self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuite >> benchNotifyRunner [
 	runner notifyRunnerWasExecuted.
 	^ self

--- a/repository/SMark/SMarkTestRunnerSuiteForAutosizing.class.st
+++ b/repository/SMark/SMarkTestRunnerSuiteForAutosizing.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #SMarkTestRunnerSuiteForAutosizing,
-	#superclass : #SMarkSuite,
-	#category : 'SMark-Tests'
+	#name : 'SMarkTestRunnerSuiteForAutosizing',
+	#superclass : 'SMarkSuite',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForAutosizing class >> defaultRunner [
 	^ SMarkTestRunner
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForAutosizing >> baseBenchmark [
 	(Delay forMilliseconds: 5) wait.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForAutosizing >> benchBig [
 	(Delay forMilliseconds: 100) wait.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForAutosizing >> benchSmall [
 	(Delay forMilliseconds: 5) wait.
 ]

--- a/repository/SMark/SMarkTestRunnerSuiteForPerfromBenchmark.class.st
+++ b/repository/SMark/SMarkTestRunnerSuiteForPerfromBenchmark.class.st
@@ -1,46 +1,48 @@
 Class {
-	#name : #SMarkTestRunnerSuiteForPerfromBenchmark,
-	#superclass : #SMarkSuite,
-	#category : 'SMark-Tests'
+	#name : 'SMarkTestRunnerSuiteForPerfromBenchmark',
+	#superclass : 'SMarkSuite',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark class >> defaultRunner [
 	^ SMarkTestRunner
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark >> BenchShouldNotBeExecuted [
 	"This one should not be executed"
 	(Delay forMilliseconds: 5) wait.
 	runner didPerform: #BenchShouldNotBeExecuted.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark >> baseBenchmark [
 	(Delay forMilliseconds: 5) wait.
 	runner didPerform: #baseBenchmark.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark >> benchAfsdfsdfsdf [
 	(Delay forMilliseconds: 5) wait.
 	runner didPerform: #benchAfsdfsdfsdf.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark >> benchBsdfasereSDSfsdfsdfs [
 	(Delay forMilliseconds: 5) wait.
 	runner didPerform: #benchBsdfasereSDSfsdfsdfs.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark >> benchC [
 	(Delay forMilliseconds: 5) wait.
 	runner didPerform: #benchC.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestRunnerSuiteForPerfromBenchmark >> benchZZ [
 	(Delay forMilliseconds: 5) wait.
 	runner didPerform: #benchZZ.

--- a/repository/SMark/SMarkTestSuite.class.st
+++ b/repository/SMark/SMarkTestSuite.class.st
@@ -2,56 +2,58 @@
 This class is used for unit testing only.
 "
 Class {
-	#name : #SMarkTestSuite,
-	#superclass : #SMarkSuite,
+	#name : 'SMarkTestSuite',
+	#superclass : 'SMarkSuite',
 	#instVars : [
 		'a',
 		'b',
 		'c',
 		'd'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite class >> defaultRunner [
 	^ SMarkTestRunner
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite class >> isAbstractClass [
 	"This is more like a hack, but we do not want to execute this as a benchmark"
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> a [
 	^a
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> b [
 	^b
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> benchA [
 	a := #executed.
 	(Delay forMilliseconds: 1) wait.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> benchB [
 	b := #executed.
 	(Delay forMilliseconds: 1) wait.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> benchC [
 	c := #executed.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> benchWithMultipleCriteria [
 	| t1 t2 t3 |
 	t3 := runner createTimer: 't3'.
@@ -73,17 +75,17 @@ SMarkTestSuite >> benchWithMultipleCriteria [
 	t1 stop.    
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> c [
 	^c
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> d [
 	^d
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 SMarkTestSuite >> initialize [
 	super initialize.
 	
@@ -95,22 +97,22 @@ SMarkTestSuite >> initialize [
 	
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkTestSuite >> setUp [
 	runner countSetUpInvoke
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> setUpBenchB [
 	runner didSetUpBenchB
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SMarkTestSuite >> tearDown [
 	runner countTearDownInvoke
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuite >> tearDownBenchC [
 	runner didTearDownBenchC
 ]

--- a/repository/SMark/SMarkTestSuiteWithBaseBenchmark.class.st
+++ b/repository/SMark/SMarkTestSuiteWithBaseBenchmark.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SMarkTestSuiteWithBaseBenchmark,
-	#superclass : #SMarkTestSuite,
-	#category : 'SMark-Tests'
+	#name : 'SMarkTestSuiteWithBaseBenchmark',
+	#superclass : 'SMarkTestSuite',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestSuiteWithBaseBenchmark >> baseBenchmark [
 	runner didRunBaseBenchmark.
 ]

--- a/repository/SMark/SMarkTestWeakScalingRunner.class.st
+++ b/repository/SMark/SMarkTestWeakScalingRunner.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #SMarkTestWeakScalingRunner,
-	#superclass : #SMarkWeakScalingRunner,
+	#name : 'SMarkTestWeakScalingRunner',
+	#superclass : 'SMarkWeakScalingRunner',
 	#instVars : [
 		'setUpCount',
 		'tearDownCount',
@@ -10,50 +10,52 @@ Class {
 		'didSetUpBenchB',
 		'didTearDownBenchC'
 	],
-	#category : 'SMark-Tests'
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> baseBenchmarkExecuted [
 	^ baseBenchmarkExecuted
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> countSetUpInvoke [
 	setUpCount := setUpCount + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> countTearDownInvoke [
 	tearDownCount := tearDownCount + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> countWasExecuted [
 	^ notifyRunnerWasExecuted 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> didPerform: aSymbol [
 	performedBenchmarks add: aSymbol.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> didRunBaseBenchmark [
 	baseBenchmarkExecuted := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> didSetUpBenchB [
 	didSetUpBenchB := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> didTearDownBenchC [
 	didTearDownBenchC := true.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkTestWeakScalingRunner >> initialize [
 	super initialize.
 
@@ -66,22 +68,22 @@ SMarkTestWeakScalingRunner >> initialize [
 	performedBenchmarks := OrderedCollection new.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> isNotifyRunnerWasExecutedSet [
 	^ notifyRunnerWasExecuted > 0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> notifyRunnerWasExecuted [
 	notifyRunnerWasExecuted := notifyRunnerWasExecuted + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> performedBenchmarks [
 	^ performedBenchmarks
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkTestWeakScalingRunner >> setUp [
 	notifyRunnerWasExecuted := false
 ]

--- a/repository/SMark/SMarkTimer.class.st
+++ b/repository/SMark/SMarkTimer.class.st
@@ -5,17 +5,18 @@ A subclass can measure alternative metrics, or for instance use different time s
 A subclass of SMarkRunner can then use the custom timer class by overriding SMarkRunner class >> #defaultTimer.
 "
 Class {
-	#name : #SMarkTimer,
-	#superclass : #Object,
+	#name : 'SMarkTimer',
+	#superclass : 'Object',
 	#instVars : [
 		'startTime',
 		'elapsedTime',
 		'name'
 	],
-	#category : 'SMark'
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SMarkTimer class >> new: aName [
 	| timer |
 	
@@ -25,40 +26,40 @@ SMarkTimer class >> new: aName [
 	^timer
 ]
 
-{ #category : #timing }
+{ #category : 'timing' }
 SMarkTimer >> currentMillis [
 
 	^ Time millisecondClockValue
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkTimer >> initialize [
 	super initialize.
 	elapsedTime := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkTimer >> name [
 	^name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkTimer >> name: aString [
 	name := aString 
 ]
 
-{ #category : #timing }
+{ #category : 'timing' }
 SMarkTimer >> reset [
 	startTime := 0.
 	elapsedTime := 0.
 ]
 
-{ #category : #timing }
+{ #category : 'timing' }
 SMarkTimer >> start [
 	startTime := self currentMillis.
 ]
 
-{ #category : #timing }
+{ #category : 'timing' }
 SMarkTimer >> stop [
 	| elapsedInThisPeriod current |
 	current := self currentMillis.
@@ -68,7 +69,7 @@ SMarkTimer >> stop [
 	elapsedTime := elapsedTime + elapsedInThisPeriod.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkTimer >> totalTime [
 	^elapsedTime
 ]

--- a/repository/SMark/SMarkTimerTest.class.st
+++ b/repository/SMark/SMarkTimerTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SMarkTimerTest,
-	#superclass : #TestCase,
-	#category : 'SMark-Tests'
+	#name : 'SMarkTimerTest',
+	#superclass : 'TestCase',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkTimerTest >> testName [
 	| timer |
 	timer := SMarkTimer new.
@@ -16,7 +18,7 @@ SMarkTimerTest >> testName [
 	self assert: timer name equals: #foo.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkTimerTest >> testReset [
 	| timer |
 	timer := SMarkTimer new.
@@ -32,7 +34,7 @@ SMarkTimerTest >> testReset [
 	self assert: timer totalTime equals: 0.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkTimerTest >> testStartStop [
 	| timer |
 	timer := SMarkTimer new.
@@ -48,7 +50,7 @@ SMarkTimerTest >> testStartStop [
 	self assert: (timer totalTime >= 10).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkTimerTest >> testTotalTimeWithResume [
 	| timer |
 	timer := SMarkTimer new.

--- a/repository/SMark/SMarkTransporter.class.st
+++ b/repository/SMark/SMarkTransporter.class.st
@@ -6,12 +6,13 @@ Thus, it is just a dummy class for future use, and to hold #transportersForFileO
 
 "
 Class {
-	#name : #SMarkTransporter,
-	#superclass : #Object,
-	#category : 'SMark'
+	#name : 'SMarkTransporter',
+	#superclass : 'Object',
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #transporter }
+{ #category : 'transporter' }
 SMarkTransporter class >> transportersForFileOutMenu [
 	^ { (Smalltalk at: #Transporter ifAbsent: [^#()])
 			forPackage: (PackageInfo named: 'SMark') }

--- a/repository/SMark/SMarkWeakScalingRunner.class.st
+++ b/repository/SMark/SMarkWeakScalingRunner.class.st
@@ -4,25 +4,26 @@ This runner is specific to platforms with support for real parallelism.
 Weak scaling is defined as how the solution time varies with the number of processors for a fixed problem size per processor.
 "
 Class {
-	#name : #SMarkWeakScalingRunner,
-	#superclass : #SMarkRunner,
+	#name : 'SMarkWeakScalingRunner',
+	#superclass : 'SMarkRunner',
 	#instVars : [
 		'numInnerIterations',
 		'runningProcesses',
 		'completionSignal',
 		'runningProcessesMtx'
 	],
-	#category : 'SMark'
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SMarkWeakScalingRunner class >> defaultNumberOfInnerIterations [
 	"The number of iterations of the inner loop
 	 in which the benchmark is executed."
 	^ 1
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> execute: aSelector withProcesses: numberOfProcesses withTimer: timer [
 	"This case is meant for all cases. REM: this is also used for numProc==1 to be able to measure the process start overhead in all cases.
 	 It will start the processes and wait for their completion."
@@ -53,7 +54,7 @@ SMarkWeakScalingRunner >> execute: aSelector withProcesses: numberOfProcesses wi
 	
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> executorCompleted [
 	runningProcessesMtx critical: [
 		runningProcesses := runningProcesses - 1.
@@ -63,7 +64,7 @@ SMarkWeakScalingRunner >> executorCompleted [
 	]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SMarkWeakScalingRunner >> initialize [
 	super initialize.
 	numProcesses			:= self class defaultNumberOfProcesses.
@@ -71,35 +72,35 @@ SMarkWeakScalingRunner >> initialize [
 
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> innerIterations [
 	"The number of inner iterations the benchmark is executed inside a processes"
 	^ numInnerIterations
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> innerIterations: anInteger [
 	"The number of inner iterations the benchmark is executed inside a processes"
 	numInnerIterations := anInteger
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> processes [
 	^ numProcesses
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> processes: anInteger [
 	numProcesses := anInteger
 ]
 
-{ #category : #reporting }
+{ #category : 'reporting' }
 SMarkWeakScalingRunner >> reportConfiguration: aStream [
 	super reportConfiguration: aStream.
 	aStream << ('inner iterations: ', numInnerIterations asString); cr.
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunner >> timedBenchmarkExecution: aSelector [
 	"Will do a timed execution of the benchmark and return the result timer"
 	| timer |

--- a/repository/SMark/SMarkWeakScalingRunnerExecutor.class.st
+++ b/repository/SMark/SMarkWeakScalingRunnerExecutor.class.st
@@ -1,16 +1,17 @@
 Class {
-	#name : #SMarkWeakScalingRunnerExecutor,
-	#superclass : #Object,
+	#name : 'SMarkWeakScalingRunnerExecutor',
+	#superclass : 'Object',
 	#instVars : [
 		'numInnerIterations',
 		'benchmarkSelector',
 		'suite',
 		'runner'
 	],
-	#category : 'SMark'
+	#category : 'SMark',
+	#package : 'SMark'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkWeakScalingRunnerExecutor class >> createFor: aSelector for: numIterations with: aRunner and: aSuite [
 	| o |
 	o := self new.
@@ -21,17 +22,17 @@ SMarkWeakScalingRunnerExecutor class >> createFor: aSelector for: numIterations 
 	^ ([ o run ] newProcess)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkWeakScalingRunnerExecutor >> benchmarkSelector: aSelector [
 	benchmarkSelector := aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkWeakScalingRunnerExecutor >> innerIterations: anInt [
 	numInnerIterations := anInt
 ]
 
-{ #category : #benchmarking }
+{ #category : 'benchmarking' }
 SMarkWeakScalingRunnerExecutor >> run [
 	1 to: numInnerIterations do: [:i |
 		suite perform: benchmarkSelector.].
@@ -39,12 +40,12 @@ SMarkWeakScalingRunnerExecutor >> run [
 	runner executorCompleted.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkWeakScalingRunnerExecutor >> runner: aRunner [
 	runner := aRunner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SMarkWeakScalingRunnerExecutor >> suite: aSuite [
 	suite := aSuite
 ]

--- a/repository/SMark/SMarkWeakScalingRunnerTest.class.st
+++ b/repository/SMark/SMarkWeakScalingRunnerTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #SMarkWeakScalingRunnerTest,
-	#superclass : #SMarkRunnerTest,
-	#category : 'SMark-Tests'
+	#name : 'SMarkWeakScalingRunnerTest',
+	#superclass : 'SMarkRunnerTest',
+	#category : 'SMark-Tests',
+	#package : 'SMark',
+	#tag : 'Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SMarkWeakScalingRunnerTest class >> shouldInheritSelectors [
 	^ true
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 SMarkWeakScalingRunnerTest >> runnerClass [
 	^ SMarkTestWeakScalingRunner
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkWeakScalingRunnerTest >> testInnerIterations [
 	"Test the semantics of the inner loop parameter"
 	| runner results |
@@ -62,7 +64,7 @@ SMarkWeakScalingRunnerTest >> testInnerIterations [
 	self assert: 4           equals: (results at: #NotifyRunner) size.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkWeakScalingRunnerTest >> testWeakScaling3Processes [
 	"test with small number of processes and varying number of iterations"
 	| runner results |
@@ -78,7 +80,7 @@ SMarkWeakScalingRunnerTest >> testWeakScaling3Processes [
 	self assert: 2 equals: (results at: #NotifyRunner) size.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkWeakScalingRunnerTest >> testWeakScalingFewProcesses [
 	"test with small number of processes and varying number of iterations"
 	| runner results |
@@ -94,7 +96,7 @@ SMarkWeakScalingRunnerTest >> testWeakScalingFewProcesses [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SMarkWeakScalingRunnerTest >> testWeakScalingManyProcesses [
 	"test with large number of processes and varying number of iterations"
 	| runner results |

--- a/repository/SMark/package.st
+++ b/repository/SMark/package.st
@@ -1,1 +1,1 @@
-Package { #name : #SMark }
+Package { #name : 'SMark' }


### PR DESCRIPTION
This PR addresses a reporting issue where the output stream (when the output is not the ScriptConsole, the default) was not being properly flushed to disk. The problem resulted in incomplete or missing reports in certain scenarios. This fix ensures that all data written to the output stream is correctly flushed to disk, guaranteeing complete reports.

Changes Made:

- Add a flush in the reporting code responsible for writing data to the output stream.
- Added a test to ensure its effectiveness and correctness. The test case cover the situation where the output stream was not written. The test have passed successfully.

